### PR TITLE
X Content Type Options Header Missing

### DIFF
--- a/index/signUp.php
+++ b/index/signUp.php
@@ -1,4 +1,5 @@
 <?php
+header('X-Content-Type-Options: nosniff');
 header_remove('X-Powered-By');
 session_start();
 include('functions.php');


### PR DESCRIPTION
Alert Description - The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'. This allows older versions of Internet Explorer and Chrome to perform MIME-sniffing on the response body, potentially causing the response body to be interpreted and displayed as a content type other than the declared content type. Current (early 2014) and legacy versions of Firefox will use the declared content type (if one is set), rather than performing MIME-sniffing.